### PR TITLE
Adding `sys._getframe()` fallback

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -6,7 +6,9 @@ __all__ = [
 
 import sys
 
-if not hasattr(sys, '_getframe'):
+NATIVE = hasattr(sys, '_getframe')
+
+if not NATIVE:
     try:
         raise
     except:
@@ -59,8 +61,6 @@ class Frame:
     Wrapper object for the internal frames.
     '''
 
-    NATIVE = hasattr(sys, '_getframe')
-
     class Error(Exception):
         '''
         The base for everything frame related going wrong in the module.
@@ -84,7 +84,7 @@ class Frame:
         # `import sys` is important here, because the `sys` module is special
         # and we will end up with the class frame instead of the `current` one.
 
-        frame = (__import__('sys')._getframe() if Frame.NATIVE else _getframe()).f_back
+        frame = (__import__('sys')._getframe() if NATIVE else _getframe()).f_back
 
         if not raw:
             frame = Frame(frame)

--- a/test.py
+++ b/test.py
@@ -66,5 +66,5 @@ if __name__ == "__main__":
     suite.run()
 
     print "\nNon-Native Tests..."
-    frames.Frame.NATIVE = False
+    frames.NATIVE = False
     suite.run()


### PR DESCRIPTION
If the current implementation of Python doesn't have `sys._getframe()`, this function should be able to fill in, albeit twice as slowly.

This fallback works, but I wasn't sure of the best way to rewrite `tests.py` to include it. Ideally you could just `delattr(sys, '_getframe')` and then re-run the tests, but I'm not aware of how to do this with attest.

(This is my first GitHub pull request, so I apologize if I've messed some part of it up.)
